### PR TITLE
#58: Upgrading plugin for IntelliJ 2021.2

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -12,7 +12,7 @@ jobs:
 
     # Validate wrapper
     - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@v1.0.3
+      uses: gradle/wrapper-validation-action@v1
 
   # Run verifyPlugin and test Gradle tasks
   test:
@@ -118,6 +118,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout "ide-versions" File for the Verifier Action to Use
+      uses: actions/checkout@v2
 
     # Download plugin artifact provided by the previous job.
     # This will auto-extract zip contents into the current directory
@@ -125,9 +127,6 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: plugin-artifact
-
-    - name: Checkout "ide-versions" File for the Verifier Action to Use
-      uses: actions/checkout@v2
 
     # Run IntelliJ Plugin Verifier action using GitHub Action
     - name: Verify Plugin Compatibility

--- a/.github/workflows/ide_versions_to_verify.txt
+++ b/.github/workflows/ide_versions_to_verify.txt
@@ -1,4 +1,4 @@
-ideaIC:2020.1
+ideaIC:2021.2
 ideaIC:LATEST-EAP-SNAPSHOT
-pycharmPC:2020.1
+pycharmPC:2021.2
 pycharmPC:LATEST-EAP-SNAPSHOT

--- a/.run/View dependency tree.run.xml
+++ b/.run/View dependency tree.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="View dependency tree" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="dependencies" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list />
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
+- Dependencies updated to support IntelliJ 2021.2.
+
+### Removed
+- Dropped support for IntelliJ 2020.1 - 2021.1 due to breaking API changes in 2021.2.
 
 ## [0.8.0] - 2021-05-10
 #### (compatibility: 2020.1 - 2021.1.*)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,9 @@ fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "0.7.2"
-    id("org.jetbrains.grammarkit") version "2021.1.1"
-    kotlin("jvm") version "1.4.32"
+    id("org.jetbrains.intellij") version "1.1.4"
+    id("org.jetbrains.grammarkit") version "2021.1.3"
+    kotlin("jvm") version "1.5.21"
     jacoco
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
     id("org.barfuin.gradle.jacocolog") version "1.2.4" // show coverage in console
@@ -43,9 +43,9 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2020.1"
-    type = "PC"
-    setPlugins("com.github.b3er.idea.plugins.arc.browser:0.23")
+    version.set("2021.2")
+    type.set("PC")
+    plugins.set(listOf("com.github.b3er.idea.plugins.arc.browser:0.23"))
 }
 
 ktlint {
@@ -65,7 +65,7 @@ val generateAhkParser = task<GenerateParser>("generateAhkParser") {
     targetRoot = "src/main/gen"
     pathToParser = "de/nordgedanken/auto_hotkey/lang/parser/AhkParser.java"
     pathToPsiRoot = "de/nordgedanken/auto_hotkey/lang/psi"
-    purgeOldFiles = true
+    purgeOldFiles = false
 }
 
 changelog {
@@ -87,35 +87,33 @@ tasks {
     }
 
     patchPluginXml {
-        changeNotes(
-            closure {
+        changeNotes.set(
+            provider {
                 changelog.get(changelog.version).withHeader(true).toHTML() +
                     """Please see <a href=
                         |"https://github.com/Nordgedanken/intellij-autohotkey/blob/master/CHANGELOG.md"
                         |>CHANGELOG.md</a> for a full list of changes.""".trimMargin()
             }
         )
-        pluginDescription(
-            closure {
-                File("$rootDir/README.md").readText().lines().run {
-                    val start = "<!-- Plugin description -->"
-                    val end = "<!-- Plugin description end -->"
-                    if (!containsAll(listOf(start, end))) {
-                        throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
-                    }
-                    subList(indexOf(start) + 1, indexOf(end))
-                }.joinToString("\n").run { markdownToHTML(this) }
-            }
+        pluginDescription.set(
+            File("$rootDir/README.md").readText().lines().run {
+                val start = "<!-- Plugin description -->"
+                val end = "<!-- Plugin description end -->"
+                if (!containsAll(listOf(start, end))) {
+                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+                }
+                subList(indexOf(start) + 1, indexOf(end))
+            }.joinToString("\n").run { markdownToHTML(this) }
         )
-        version(changelog.version)
-        sinceBuild(properties("pluginSinceBuild"))
-        untilBuild(properties("pluginUntilBuild"))
+        version.set(changelog.version)
+        sinceBuild.set(properties("pluginSinceBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
     }
 
     val intellijPublishToken: String? by project
     publishPlugin {
         if (intellijPublishToken != null) {
-            token(intellijPublishToken)
+            token.set(intellijPublishToken)
         }
     }
 
@@ -156,7 +154,7 @@ tasks {
     }
 
     runPluginVerifier {
-        ideVersions(properties("pluginVerifierIdeVersions"))
+        ideVersions.set(properties("pluginVerifierIdeVersions").split(',').map(String::trim).filter(String::isNotEmpty))
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 pluginVersion = 0.8.0
-pluginSinceBuild = 201
-pluginUntilBuild = 211.*
+pluginSinceBuild = 212
+pluginUntilBuild = 212.*
 
-pluginVerifierIdeVersions = 2020.1.1, 2021.1
+pluginVerifierIdeVersions = 2021.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/commenter/AhkCommenter.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/commenter/AhkCommenter.kt
@@ -106,7 +106,7 @@ class AhkCommenter : IndentedCommenter, SelfManagingCommenter<AhkCommentHolder> 
     }
 
     override fun forceIndentedLineComment() = false
-    override fun forceIndentedBlockComment() = true
+    override fun forceIndentedBlockComment() = false
 }
 
 /**

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/linemarkers/AhkExecutableRunLineMarkerContributor.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/linemarkers/AhkExecutableRunLineMarkerContributor.kt
@@ -4,8 +4,8 @@ import com.intellij.execution.lineMarker.ExecutorAction
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
 import com.intellij.icons.AllIcons
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.descendantsOfType
 import com.intellij.psi.util.elementType
-import com.intellij.psi.util.findDescendantOfType
 import com.intellij.refactoring.suggested.startOffset
 import de.nordgedanken.auto_hotkey.lang.psi.AhkLine
 import de.nordgedanken.auto_hotkey.lang.psi.COMMENT_TOKENS
@@ -17,7 +17,7 @@ import de.nordgedanken.auto_hotkey.lang.psi.isLeaf
 class AhkExecutableRunLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? {
         if (!element.isLeaf() || element.elementType in COMMENT_TOKENS) return null
-        val firstElem = element.containingFile.findDescendantOfType<AhkLine>()
+        val firstElem = element.containingFile.descendantsOfType<AhkLine>().firstOrNull()
         if (element.startOffset != firstElem?.originalElement?.startOffset) return null
 
         val actions = ExecutorAction.getActions(0)

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/sdk/AhkSdkType.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/sdk/AhkSdkType.kt
@@ -146,7 +146,7 @@ object AhkSdkType : SdkType("AutoHotkeySDK") {
         sdkModel: SdkModel,
         parentComponent: JComponent,
         selectedSdk: Sdk?,
-        sdkCreatedCallback: Consumer<Sdk>
+        sdkCreatedCallback: Consumer<in Sdk>
     ) {
         val newSdk = showUiToCreateNewAhkSdk()
         if (newSdk != null) {


### PR DESCRIPTION
## PR for #58
closes #58

### Changes:
- Change plugin dependencies to support 2021.2
- Drop support for 2020.1-2021.1

### Testing Proof:
Builds passed. Successfully ran IDE on local

### Screenshots:
N/A
