### PR TITLE
#62: Upgrading plugin for IntelliJ 2021.3. Minor fix to improve Ahk sdk auto-naming format.

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -62,6 +62,17 @@ jobs:
     - name: Run KtLinter
       run: ./gradlew ktlintCheck
 
+    # Run Qodana code inspections
+    - name: Run Qodana Code Inspection
+      uses: JetBrains/qodana-action@v3.2.1
+
+    # Collect Qodana Result
+    - name: Collect Qodana Result
+      uses: actions/upload-artifact@v2
+      with:
+        name: qodana-result
+        path: ${{ github.workspace }}/qodana
+
     # Run test Gradle task
     - name: Run Tests
       run: ./gradlew test

--- a/.github/workflows/ide_versions_to_verify.txt
+++ b/.github/workflows/ide_versions_to_verify.txt
@@ -1,4 +1,6 @@
 ideaIC:2021.2
+ideaIC:2021.3
 ideaIC:LATEST-EAP-SNAPSHOT
 pycharmPC:2021.2
+pycharmPC:2021.3
 pycharmPC:LATEST-EAP-SNAPSHOT

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ gradle-app.setting
 src/main/gen/
 idea-flex.skeleton
 jflex-1.7.0-2.jar
+.qodana
 
 # NO java files should be committed. Only kotlin code will be accepted for PRs.
 *.java

--- a/.run/Run Qodana.run.xml
+++ b/.run/Run Qodana.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Qodana" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="QODANA_SHOW_REPORT" value="true" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="cleanInspections runInspections" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list />
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/View dependency tree (buildEnvironment).run.xml
+++ b/.run/View dependency tree (buildEnvironment).run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="View dependency tree (buildEnvironment)" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="buildEnvironment" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list />
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
+- Dependencies updated to support IntelliJ 2021.3.
+- Default name of new sdks now includes the patch version
 
 ## [0.9.0] - 2021-08-14
 #### (compatibility: 2021.2.*)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 pluginVersion = 0.9.0
 pluginSinceBuild = 212
-pluginUntilBuild = 212.*
+pluginUntilBuild = 213.*
 
-pluginVerifierIdeVersions = 2021.2
+pluginVerifierIdeVersions = 2021.2, 2021.3


### PR DESCRIPTION
## PR for #62
closes #62 

### Changes:
- Adds support for IJ 2021.3
- Minor change to include minor version in default naming of new sdks
