### PR TITLE
#64: Add right-click option in Project view to compile scripts to exe

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -143,6 +143,8 @@ jobs:
     - name: Verify Plugin Compatibility
       id: verify
       uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         plugin-location: '*.zip'
         # NOTE: For ide-versions, we just need to verify IJ community & one non-IJ IDE.

--- a/.github/workflows/ide_versions_to_verify.txt
+++ b/.github/workflows/ide_versions_to_verify.txt
@@ -1,6 +1,4 @@
 ideaIC:2021.2
 ideaIC:2021.3
-ideaIC:LATEST-EAP-SNAPSHOT
 pycharmPC:2021.2
 pycharmPC:2021.3
-pycharmPC:LATEST-EAP-SNAPSHOT

--- a/.github/workflows/verify_pr.yml
+++ b/.github/workflows/verify_pr.yml
@@ -6,7 +6,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Verify Changelog Updated
-      uses: takanuva15/verify-changelog-updated@v1
+      uses: takanuva15/verify-file-updated@v1
+  check_readme:
+    name: Verify Readme Updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Readme Updated
+        uses: takanuva15/verify-file-updated@v1
+        with:
+          excused_label: readme update optional
+          filename_to_check: README.md
+  check_contributing:
+    name: Verify Contributing Updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Contributing Updated
+        uses: takanuva15/verify-file-updated@v1
+        with:
+          excused_label: contributing update optional
+          filename_to_check: CONTRIBUTING.md
   verify_pr_and_commit_messages:
     name: Verify PR Title and Commit Message Format
     runs-on: ubuntu-latest
@@ -26,3 +44,4 @@ jobs:
           history readable when performing searches. Please see CONTRIBUTING.md for more details.
         checkAllCommitMessages: true
         accessToken: ${{ secrets.GITHUB_TOKEN }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- "Compile to exe" action available when right-clicking on Ahk files in the project tree
 
 ## [0.9.1] - 2021-12-10
 #### (compatibility: 2021.2.* - 2021.3.*)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the IntelliJ AutoHotkey Plugin
 
-First of all, thanks for taking the time to contribute! This entire plugin is built from open-source code with the efforts of developers like you who want to make better software for the benefit of everyone (in their spare time, no less!)
+First, thanks for taking the time to contribute! This entire plugin is built from open-source code with the efforts of developers like you who want to make better software for the benefit of everyone (in their spare time, no less!)
 
 ## Table of Contents
 [Code of Conduct](#code-of-conduct)
@@ -23,7 +23,7 @@ First of all, thanks for taking the time to contribute! This entire plugin is bu
 * [Documentation Styleguide](#documentation-styleguide)
 
 ## Code of Conduct
-This project and everyone participating in it is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior by posting an issue to the repo.
+This project and all its participants are governed by the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior by posting an issue to the repo.
 
 ## I don't want to read this whole thing I just have a question!!!
 Please check the [issues](https://github.com/Nordgedanken/intellij-autohotkey/issues) and [discussions](https://github.com/Nordgedanken/intellij-autohotkey/discussions) to see whether your question has already been answered. If not, please open a new discussion if you have a simple question, or raise a new issue if you're having a problem.
@@ -32,38 +32,39 @@ Please check the [issues](https://github.com/Nordgedanken/intellij-autohotkey/is
 ### Plugin Feature Locations
 The package structure has been designed to separate each plugin feature into its own package.
 
-_All package listed in the table below are prefixed with `src\main\kotlin\de\nordgedanken\auto_hotkey`._
+_All packages listed below are prefixed with `src\main\kotlin\de\nordgedanken\auto_hotkey`_
 
 #### Language-related Features
-| Feature | Location |
-| ------- | -------- |
-| Ahk token lexer (parses text to see if it's a comment, linefeed, etc) | `lang.lexer.AutoHotkey.flex` |
-| Ahk grammar parser (takes tokens from lexer and groups them into elements. Eg `'#' + word = directive`) | `lang.parser.AutoHotkey.bnf` |
-| Syntax Highlighting - simple (requires token lexer) | `ide.highlighter.AhkSyntaxHighlighter` |
-| Syntax Highlighting - advanced (requires parser) | `ide.highlighter.AhkHighlightAnnotator` |
+| Feature                                                                             | Location                                |
+|-------------------------------------------------------------------------------------|-----------------------------------------|
+| Ahk token lexer (parses text to see if it's a comment, linefeed, etc)               | `lang.lexer.AutoHotkey.flex`            |
+| Ahk grammar parser (groups lexer tokens into elements. Eg `'#' + word = directive`) | `lang.parser.AutoHotkey.bnf`            |
+| Syntax Highlighting - simple (requires token lexer)                                 | `ide.highlighter.AhkSyntaxHighlighter`  |
+| Syntax Highlighting - advanced (requires parser)                                    | `ide.highlighter.AhkHighlightAnnotator` |
 
 #### IDE Actions-related Features
-| Feature | Location |
-| ------- | -------- |
-| Line/Block Commenter via shortcut | `ide.commenter.AhkCommenter` |
-| New Ahk File action in project tree context menu | `ide.actions.AhkCreateFileAction` |
-| Run button in editor gutter | `ide.linemarkers.AhkExecutableRunLineMarkerContributor` |
-| Notification when editor opened without Ahk runners set | `ide.notifications.MissingAhkSdkNotificationProvider` |
-| Quick Documentation popup | `ide.documentation.AhkDocumentationProvider` |
+| Feature                                                 | Location                                                |
+|---------------------------------------------------------|---------------------------------------------------------|
+| Line/Block commenting via shortcut                      | `ide.commenter.AhkCommenter`                            |
+| New Ahk File action in project tree context menu        | `ide.actions.AhkCreateFileAction`                       |
+| Compile to exe action in project tree context menu      | `ide.actions.AhkCompileToExeAction`                     |
+| Run button in editor gutter                             | `ide.linemarkers.AhkExecutableRunLineMarkerContributor` |
+| Notification when editor opened without Ahk runners set | `ide.notifications.MissingAhkSdkNotificationProvider`   |
+| Quick Documentation popup                               | `ide.documentation.AhkDocumentationProvider`            |
 
 
 #### Execution-related Features
-| Feature | Location |
-| ------- | -------- |
-| Run configuration definition | `runconfig.core.AhkRunConfig` |
-| Run configuration producer for context menu (shows a run option when right-clicking an Ahk file in the context menu | `runconfig.producer.AhkRunConfigProducer` |
-| Run configuration UI | `runconfig.ui.AhkRunConfigSettingsEditor` |
-| Ahk runner definition | `sdk.AhkSdkType` |
-| Ahk runner renderer (for UI elements where you display a runner) | `sdk.ui.*` |
+| Feature                                                                       | Location                                  |
+|-------------------------------------------------------------------------------|-------------------------------------------|
+| Run configuration definition                                                  | `runconfig.core.AhkRunConfig`             |
+| Run configuration producer (shows run option when right-clicking an Ahk file) | `runconfig.producer.AhkRunConfigProducer` |
+| Run configuration UI                                                          | `runconfig.ui.AhkRunConfigSettingsEditor` |
+| Ahk runner definition                                                         | `sdk.AhkSdkType`                          |
+| Ahk runner renderer (for UI elements where you display a runner)              | `sdk.ui.*`                                |
 
 #### Miscellaneous Features
-| Feature | Location |
-| ------- | -------- |
+| Feature              | Location                                      |
+|----------------------|-----------------------------------------------|
 | Ahk project settings | `project.configurable.AhkProjectConfigurable` |
 
 
@@ -93,7 +94,7 @@ To contribute:
 
 #### Code requirements: 
 - All classes must have documentation
-- New code must have tests written such that the code coverage does not fall below a certain threshold.
+- New code must have tests written such that the code coverage does not fall below the configured threshold.
 - The changelog must be updated
 - This contributing file must be updated if a new feature or extension point is added
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A simple plugin for developing AutoHotkey scripts. The following features are av
 - Syntax highlighting (under construction; v1 only; no error checking available currently)
 - Run configurations (v1 and v2)
 - Quick documentation
+- Compile to exe (file right-click option)
 - More to come in the future... 
 
 Check out the <a href="https://github.com/Nordgedanken/intellij-autohotkey#usage">README</a> on the plugin's GitHub page for more information on using this plugin.
@@ -92,6 +93,8 @@ Install the plugin from the [JetBrains Marketplace][jetbrains-marketplace-plugin
   > Note: The hyperlink shown at the bottom of the documentation popup will link to either the v1 or v2 documentation based on which executable you selected as the default in the AutoHotkey settings page.
 - **Line/Block Commenting**  
   Comments are toggled by selecting the comment action within the "Code" menu
+- **Compile to Executable**  
+  Right-click an AutoHotkey file in the project tree and select the "Compile to exe" option to [compile it to .exe][ahk-doc-url-for-ahk2exe]
 
 
 
@@ -168,3 +171,4 @@ Project Link: [https://github.com/Nordgedanken/intellij-autohotkey](https://gith
 [product-screenshot]: images/screenshot.png
 
 [jetbrains-marketplace-plugin-page]: https://plugins.jetbrains.com/plugin/13945-autohotkey/
+[ahk-doc-url-for-ahk2exe]: https://www.autohotkey.com/docs/Scripts.htm#ahk2exe

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "1.3.+"
+    id("org.jetbrains.intellij") version "1.4.+"
     id("org.jetbrains.grammarkit") version "2021.1.+"
     kotlin("jvm") version "1.6.+"
     jacoco
@@ -19,7 +19,8 @@ plugins {
     id("org.jetbrains.qodana") version "0.1.+"
 }
 
-group = "de.nordgedanken"
+group = properties("pluginGroup")
+version = properties("pluginVersion")
 
 // Include the generated files in the source set
 sourceSets.main.get().java.srcDirs("src/main/gen")
@@ -45,7 +46,7 @@ dependencies {
 intellij {
     version.set("2021.2")
     type.set("PC")
-    plugins.set(listOf("com.github.b3er.idea.plugins.arc.browser:0.23"))
+    plugins.set(properties("pluginDependencies").split(',').map(String::trim).filter(String::isNotEmpty))
 }
 
 ktlint {
@@ -93,6 +94,9 @@ tasks {
     }
 
     patchPluginXml {
+        version.set(changelog.version)
+        sinceBuild.set(properties("pluginSinceBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
         changeNotes.set(
             provider {
                 changelog.get(changelog.version.get()).withHeader(true).toHTML() +
@@ -111,9 +115,6 @@ tasks {
                 subList(indexOf(start) + 1, indexOf(end))
             }.joinToString("\n").run { markdownToHTML(this) }
         )
-        version.set(changelog.version)
-        sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
     }
 
     val intellijPublishToken: String? by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,9 @@
+pluginGroup = de.nordgedanken.auto_hotkey
+
 pluginVersion = 0.9.1
 pluginSinceBuild = 212
 pluginUntilBuild = 213.*
 
 pluginVerifierIdeVersions = 2021.2, 2021.3
+
+pluginDependencies = com.github.b3er.idea.plugins.arc.browser:0.32

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/actions/AhkCompileToExeAction.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/actions/AhkCompileToExeAction.kt
@@ -1,0 +1,111 @@
+package de.nordgedanken.auto_hotkey.ide.actions
+
+import com.intellij.icons.AllIcons
+import com.intellij.ide.actions.RevealFileAction.findLocalFile
+import com.intellij.ide.actions.RevealFileAction.openDirectory
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.wm.ToolWindowBalloonShowOptions
+import com.intellij.openapi.wm.ToolWindowId
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.BrowserHyperlinkListener
+import de.nordgedanken.auto_hotkey.lang.core.isAhkFile
+import de.nordgedanken.auto_hotkey.project.configurable.AhkProjectConfigurable
+import de.nordgedanken.auto_hotkey.project.settings.defaultAhkSdk
+import de.nordgedanken.auto_hotkey.project.settings.hasDefaultAhkSdk
+import de.nordgedanken.auto_hotkey.sdk.ahkDocUrlBase
+import de.nordgedanken.auto_hotkey.util.AhkBundle
+import de.nordgedanken.auto_hotkey.util.AhkIcons
+import java.io.File
+import java.util.concurrent.TimeUnit.SECONDS
+import javax.swing.event.HyperlinkEvent
+
+/**
+ * Defines the behavior when the user right-clicks an ahk file in the Project Tree and selects "Compile to exe"
+ */
+class AhkCompileToExeAction : DumbAwareAction(
+    AhkBundle.msg("compiletoexeaction.text"),
+    AhkBundle.msg("compiletoexeaction.description"),
+    AhkIcons.EXE
+) {
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE)?.isAhkFile() == true
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val toolWindowManager = ToolWindowManager.getInstance(e.project!!)
+        if (!e.project!!.hasDefaultAhkSdk()) {
+            return toolWindowManager.notifyByBalloon(ERROR_BALLOON_NO_RUNNER_CONFIGURED(e.project!!))
+        }
+        val defaultAhkSdkHomeDir = File(e.project!!.defaultAhkSdk!!.homePath!!)
+        val ahk2ExeFile = defaultAhkSdkHomeDir.resolve("Compiler").resolve("Ahk2Exe.exe")
+        if (!ahk2ExeFile.isFile) {
+            return toolWindowManager.notifyByBalloon(ERROR_BALLOON_NO_AHK2EXE_EXISTS(defaultAhkSdkHomeDir))
+        }
+        val scriptToCompile = findLocalFile(e.getData(CommonDataKeys.VIRTUAL_FILE))!!
+        // Below required since IDE doesn't instantly save to disk if a quick edit is made before selecting compile
+        FileDocumentManager.getInstance().run { saveDocument(getCachedDocument(scriptToCompile)!!) }
+        ProcessBuilder(ahk2ExeFile.path, "/in", scriptToCompile.path).directory(defaultAhkSdkHomeDir).start().run {
+            val processTerminated = waitFor(60, SECONDS)
+            if (!processTerminated || exitValue() != 0) {
+                return toolWindowManager.notifyByBalloon(ERROR_BALLOON_ERROR_RUNNING_AHK2EXE(scriptToCompile.name))
+            }
+            toolWindowManager.notifyByBalloon(SUCCESS_BALLOON(e.project!!.defaultAhkSdk!!.ahkDocUrlBase))
+            VfsUtil.markDirtyAndRefresh(true, false, true, scriptToCompile.parent)
+        }
+    }
+
+    companion object {
+        private val ERROR_BALLOON_NO_RUNNER_CONFIGURED = { project: Project ->
+            ToolWindowBalloonShowOptions(
+                ToolWindowId.PROJECT_VIEW,
+                MessageType.ERROR,
+                AhkBundle.msg("compiletoexeaction.error.norunnerconfigured"),
+                AllIcons.General.Error,
+                listener = {
+                    if (it.eventType == HyperlinkEvent.EventType.ACTIVATED) {
+                        ShowSettingsUtil.getInstance().showSettingsDialog(project, AhkProjectConfigurable::class.java)
+                    }
+                }
+            )
+        }
+
+        private val ERROR_BALLOON_NO_AHK2EXE_EXISTS = { sdkHomeDir: File ->
+            ToolWindowBalloonShowOptions(
+                ToolWindowId.PROJECT_VIEW,
+                MessageType.ERROR,
+                AhkBundle.msg("compiletoexeaction.error.noahk2exeexists"),
+                AllIcons.General.Error,
+                listener = {
+                    if (it.eventType == HyperlinkEvent.EventType.ACTIVATED) {
+                        openDirectory(sdkHomeDir)
+                    }
+                }
+            )
+        }
+
+        private val ERROR_BALLOON_ERROR_RUNNING_AHK2EXE = { scriptName: String ->
+            ToolWindowBalloonShowOptions(
+                ToolWindowId.PROJECT_VIEW,
+                MessageType.ERROR,
+                AhkBundle.msg("compiletoexeaction.error.errorrunningahk2exe").format(scriptName),
+                AllIcons.General.Error
+            )
+        }
+
+        private val SUCCESS_BALLOON = { ahkDocUrl: String ->
+            ToolWindowBalloonShowOptions(
+                ToolWindowId.PROJECT_VIEW,
+                MessageType.INFO,
+                AhkBundle.msg("compiletoexeaction.success.message").format(ahkDocUrl),
+                listener = BrowserHyperlinkListener.INSTANCE
+            )
+        }
+    }
+}

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/documentation/AhkDocumentationProvider.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/documentation/AhkDocumentationProvider.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import de.nordgedanken.auto_hotkey.lang.psi.AhkTokenType
 import de.nordgedanken.auto_hotkey.project.settings.defaultAhkSdk
-import de.nordgedanken.auto_hotkey.sdk.ahkDocumentationUrl
+import de.nordgedanken.auto_hotkey.sdk.ahkDocUrlBase
 
 /**
  * Provides commands/directives documentation by extracting them from the
@@ -46,13 +46,13 @@ class AhkDocumentationProvider : DocumentationProvider, ExternalDocumentationHan
         }
 
         if (element.text.startsWith("A_")) {
-            return "${element.project.defaultAhkSdk!!.ahkDocumentationUrl}/docs/Variables.htm#" + element.text.drop(2)
+            return "${element.project.defaultAhkSdk!!.ahkDocUrlBase}/docs/Variables.htm#" + element.text.drop(2)
         }
 
         val pathInChm = ChmArchiveUtil.getPathInChm(chm, element.text)
             ?: return null
 
-        return "${element.project.defaultAhkSdk!!.ahkDocumentationUrl}/$pathInChm"
+        return "${element.project.defaultAhkSdk!!.ahkDocUrlBase}/$pathInChm"
     }
 
     override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/documentation/ChmArchiveUtil.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/ide/documentation/ChmArchiveUtil.kt
@@ -1,6 +1,6 @@
 package de.nordgedanken.auto_hotkey.ide.documentation
 
-import com.github.b3er.idea.plugins.arc.browser.formats.SevenZipArchiveFileSystemImpl
+import com.github.b3er.idea.plugins.arc.browser.formats.sevenzip.SevenZipArchiveFileSystemImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.impl.ArchiveHandler
@@ -29,7 +29,6 @@ object ChmArchiveUtil {
         }
 
         return SevenZipArchiveFileSystemImpl.instance.getHandlerForFile(stub)
-            ?: error("Error initializing 7zip file system")
     }
 
     fun getPathInChm(chm: ArchiveHandler, approximateTitle: String?): String? {

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/project/settings/AhkProjectSettingsService.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/project/settings/AhkProjectSettingsService.kt
@@ -74,3 +74,5 @@ var Project.defaultAhkSdk: Sdk?
     set(newDefaultAhkSdk) {
         service<AhkProjectSettingsService>().defaultAhkSdk = newDefaultAhkSdk
     }
+
+fun Project.hasDefaultAhkSdk() = defaultAhkSdk != null

--- a/src/main/kotlin/de/nordgedanken/auto_hotkey/sdk/AhkSdkUtil.kt
+++ b/src/main/kotlin/de/nordgedanken/auto_hotkey/sdk/AhkSdkUtil.kt
@@ -24,5 +24,5 @@ fun Sdk.ahkExeName(): String {
     return (sdkAdditionalData as AhkSdkAdditionalData).exeName
 }
 
-val Sdk.ahkDocumentationUrl: String get() =
+val Sdk.ahkDocUrlBase: String get() =
     if (versionString?.startsWith("1") != false) AHK_DOCUMENTATION_URL_V1 else AHK_DOCUMENTATION_URL_V2

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,5 +62,9 @@
                 description="Create new AutoHotkey file">
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewXml"/>
         </action>
+        <action id="de.nordgedanken.auto_hotkey.ide.actions.AhkCompileToExeAction"
+                class="de.nordgedanken.auto_hotkey.ide.actions.AhkCompileToExeAction">
+            <add-to-group group-id="RunContextGroupInner" anchor="last"/>
+        </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/localization/AhkBundle.properties
+++ b/src/main/resources/localization/AhkBundle.properties
@@ -44,3 +44,10 @@ settings.general.thankyou.label=Thank you for installing the IntelliJ AutoHotkey
 documentation.error.no.runner.configured=No AutoHotkey runner configured. Please configure one first
 documentation.error.cannot.access.runner.home.dir=Cannot access Autohotkey runner home directory
 documentation.error.chm.file.not.found.in.home.dir=AutoHotkey.chm not found in Autohotkey runner home directory
+
+compiletoexeaction.text=Compile to exe
+compiletoexeaction.description=Compile the selected AutoHotkey script into an executable file
+compiletoexeaction.error.norunnerconfigured=An AutoHotkey runner is required in order to compile AutoHotkey scripts. Please <a href="open-ahk-settings">configure</a> an AutoHotkey runner first.
+compiletoexeaction.error.noahk2exeexists=Could not find "./Compiler/Ahk2Exe.exe" within the default AutoHotkey runner's directory! Please <a href="open-ahk-runner-dir-in-explorer">verify</a> whether the file exists.
+compiletoexeaction.error.errorrunningahk2exe=An error occurred or the time limit was exceeded while compiling %s. (AutoHotkey may have opened a dialog with additional details)
+compiletoexeaction.success.message=Compilation successful. (To configure additional compilation options, please use <a href="%s/docs/misc/Ahk2ExeDirectives.htm#Intro1">compiler directives</a>)

--- a/src/test/kotlin/de/nordgedanken/auto_hotkey/ide/actions/AhkCompileToExeActionTest.kt
+++ b/src/test/kotlin/de/nordgedanken/auto_hotkey/ide/actions/AhkCompileToExeActionTest.kt
@@ -1,0 +1,134 @@
+package de.nordgedanken.auto_hotkey.ide.actions
+
+import com.intellij.ide.DataManager
+import com.intellij.ide.impl.HeadlessDataManager
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.wm.ToolWindowBalloonShowOptions
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.impl.ToolWindowHeadlessManagerImpl
+import com.intellij.testFramework.TemporaryDirectory
+import com.intellij.testFramework.replaceService
+import de.nordgedanken.auto_hotkey.AhkBasePlatformTestCase
+import de.nordgedanken.auto_hotkey.ProjectDescriptor
+import de.nordgedanken.auto_hotkey.WithOneAhkSdkAsProjDefault
+import de.nordgedanken.auto_hotkey.project.settings.defaultAhkSdk
+import de.nordgedanken.auto_hotkey.sdk.ahkDocUrlBase
+import de.nordgedanken.auto_hotkey.util.AhkBundle
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.slot
+import io.mockk.spyk
+import java.nio.file.Files
+import java.nio.file.Path
+
+class AhkCompileToExeActionTest : AhkBasePlatformTestCase() {
+    private val TEST_AHK_SCRIPT_FILENAME = "test.ahk"
+
+    fun `test action does not show if triggered from a non-ahk file`() {
+        val resultPresentation = myFixture.testAction(AhkCompileToExeAction())
+        resultPresentation.isEnabledAndVisible.shouldBeFalse()
+    }
+
+    fun `test error balloon shown if no ahk sdk configured`() {
+        val balloonToCapture = mockToolWindowManagerAndCaptureBalloonNotification()
+        configureCompileToExeActionToBeCalledFromFakeAhkScript()
+        myFixture.testAction(AhkCompileToExeAction())
+        balloonToCapture.captured.run {
+            type shouldBe MessageType.ERROR
+            htmlBody shouldBe AhkBundle.msg("compiletoexeaction.error.norunnerconfigured")
+        }
+    }
+
+    @ProjectDescriptor(WithOneAhkSdkAsProjDefault::class)
+    fun `test error balloon shown if no ahk2exe file present`() {
+        val balloonToCapture = mockToolWindowManagerAndCaptureBalloonNotification()
+        configureCompileToExeActionToBeCalledFromFakeAhkScript()
+        myFixture.testAction(AhkCompileToExeAction())
+        balloonToCapture.captured.run {
+            type shouldBe MessageType.ERROR
+            htmlBody shouldBe AhkBundle.msg("compiletoexeaction.error.noahk2exeexists")
+        }
+    }
+
+    @ProjectDescriptor(WithOneAhkSdkAsProjDefault::class)
+    fun `test error balloon shown if compilation fails`() {
+        val balloonToCapture = mockToolWindowManagerAndCaptureBalloonNotification()
+        configureCompileToExeActionToBeCalledFromFakeAhkScript()
+        val sdkHomeDir = TemporaryDirectory.generateTemporaryPath("")
+        createFakeAhk2ExeFileWithin(sdkHomeDir)
+        (project.defaultAhkSdk as ProjectJdkImpl).homePath = sdkHomeDir.toString()
+
+        val mockProcess = mockProcessBuilderWithATerminatingMockProcess()
+        every { mockProcess.exitValue() } returns 1
+
+        myFixture.testAction(AhkCompileToExeAction())
+        balloonToCapture.captured.run {
+            type shouldBe MessageType.ERROR
+            htmlBody shouldBe AhkBundle.msg("compiletoexeaction.error.errorrunningahk2exe")
+                .format(TEST_AHK_SCRIPT_FILENAME)
+        }
+    }
+
+    @ProjectDescriptor(WithOneAhkSdkAsProjDefault::class)
+    fun `test success balloon shown if compilation successful`() {
+        val balloonToCapture = mockToolWindowManagerAndCaptureBalloonNotification()
+        configureCompileToExeActionToBeCalledFromFakeAhkScript()
+        val sdkHomeDir = TemporaryDirectory.generateTemporaryPath("")
+        createFakeAhk2ExeFileWithin(sdkHomeDir)
+        (project.defaultAhkSdk as ProjectJdkImpl).homePath = sdkHomeDir.toString()
+
+        val mockProcess = mockProcessBuilderWithATerminatingMockProcess()
+        every { mockProcess.exitValue() } returns 0
+
+        myFixture.testAction(AhkCompileToExeAction())
+        balloonToCapture.captured.run {
+            type shouldBe MessageType.INFO
+            htmlBody shouldBe AhkBundle.msg("compiletoexeaction.success.message")
+                .format(project.defaultAhkSdk!!.ahkDocUrlBase)
+        }
+    }
+
+    private fun mockToolWindowManagerAndCaptureBalloonNotification() = slot<ToolWindowBalloonShowOptions>().also {
+        val spyToolWindowManager = spyk(ToolWindowHeadlessManagerImpl(project))
+        every { spyToolWindowManager.notifyByBalloon(options = capture(it)) } just Runs
+        project.replaceService(ToolWindowManager::class.java, spyToolWindowManager, testRootDisposable)
+    }
+
+    private fun configureCompileToExeActionToBeCalledFromFakeAhkScript() {
+        val fakeAhkScriptFile = myFixture.configureByText(TEST_AHK_SCRIPT_FILENAME, "")!!.virtualFile
+        // Make a fake data context that pretends it was generated from the fake script
+        val dataContextWScript = DataContext {
+            return@DataContext when (it) {
+                CommonDataKeys.PROJECT.name -> project
+                CommonDataKeys.VIRTUAL_FILE.name -> fakeAhkScriptFile
+                else -> null
+            }
+        }
+        // Inject a mock DataManager to provide our fake data context when requested from the action event
+        val spyDataManager = spyk(HeadlessDataManager())
+        every { spyDataManager.dataContext } returns dataContextWScript
+        ApplicationManager.getApplication().replaceService(DataManager::class.java, spyDataManager, testRootDisposable)
+    }
+
+    private fun createFakeAhk2ExeFileWithin(dir: Path) = dir.resolve("Compiler").resolve("Ahk2Exe.exe").let {
+        Files.createDirectories(it.parent)
+        Files.createFile(it)
+    }
+
+    private fun mockProcessBuilderWithATerminatingMockProcess(): Process {
+        mockkConstructor(ProcessBuilder::class)
+        return mockk<Process>().also {
+            every { anyConstructed<ProcessBuilder>().start() } returns it
+            every { it.waitFor(any(), any()) } returns true
+        }
+    }
+}

--- a/src/test/kotlin/de/nordgedanken/auto_hotkey/sdk/AhkSdkUtilKtTest.kt
+++ b/src/test/kotlin/de/nordgedanken/auto_hotkey/sdk/AhkSdkUtilKtTest.kt
@@ -35,10 +35,10 @@ class AhkSdkUtilKtTest : AhkBasePlatformTestCase() {
         mockAhkSdk.ahkExeName() shouldBe DEFAULT_AHK_EXE_NAME
     }
 
-    fun `test ahkDocumentationUrl`() {
-        mockAhkSdk.versionString = "1.1.33.07"
-        mockAhkSdk.ahkDocumentationUrl shouldBe AHK_DOCUMENTATION_URL_V1
-        mockAhkSdk.versionString = "2.0-a133"
-        mockAhkSdk.ahkDocumentationUrl shouldBe AHK_DOCUMENTATION_URL_V2
+    fun `test ahkDocumentationUrl`() = mockAhkSdk.run {
+        versionString = "1.1.33.07"
+        ahkDocUrlBase shouldBe AHK_DOCUMENTATION_URL_V1
+        versionString = "2.0-a133"
+        ahkDocUrlBase shouldBe AHK_DOCUMENTATION_URL_V2
     }
 }


### PR DESCRIPTION
## PR for #64

closes #64

### Changes:
- Add "compile to exe" option in project tree context menu of ahk scripts

### Screenshots:
- 
![image](https://user-images.githubusercontent.com/6986426/155909714-6f96be74-20c7-48eb-ba69-5f40ee990e64.png)

